### PR TITLE
Limit nfs access; add tcpwrappers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 ---
-require: rubocop-rspec
+require:
+- rubocop-rspec
+- rubocop-i18n
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: '2.1'
@@ -19,10 +21,12 @@ AllCops:
 Metrics/LineLength:
   Description: People have wide screens, use them.
   Max: 200
+GetText:
+  Enabled: false
 GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
-  - spec/*
+  - spec/**/*
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-dist: trusty
+dist: xenial
 language: ruby
 cache: bundler
 before_install:
@@ -43,12 +43,3 @@ branches:
     - /^v\d/
 notifications:
   email: false
-deploy:
-  provider: puppetforge
-  user: puppet
-  password:
-    secure: ""
-  on:
-    tags: true
-    all_branches: true
-    condition: "$DEPLOY_TO_FORGE = yes"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "jpogran.puppet-vscode",
+    "rebornix.Ruby"
+  ]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -17,16 +17,17 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "fast_gettext", '1.1.0',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "json", '= 2.0.4',                               require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                               require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                            require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "json_pure", '<= 2.0.1',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
+  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
@@ -14,8 +15,17 @@ end
 
 def changelog_project
   return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = nil || JSON.load(File.read('metadata.json'))['name']
-  raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
+
+  returnVal = nil
+  returnVal ||= begin
+    metadata_source = JSON.load(File.read('metadata.json'))['source']
+    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
+
+    metadata_source_match && metadata_source_match[1]
+  end
+
+  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
+
   puts "GitHubChangelogGenerator project:#{returnVal}"
   returnVal
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: 1.1.x.{build}
 branches:
   only:
     - master
+    - release
 skip_commits:
   message: /^\(?doc\)?.*/
 clone_depth: 10

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -5,6 +5,8 @@
 class xcat::master {
     include ::xcat::master::bmc_smtp
     include ::xcat::master::firewall
+    include ::xcat::master::nfs
     include ::xcat::master::postscripts
     include ::xcat::master::root
+    include ::xcat::master::tcpwrappers
 }

--- a/manifests/master/nfs.pp
+++ b/manifests/master/nfs.pp
@@ -1,0 +1,61 @@
+# @summary Harden NFS settings on xcat-master
+#
+# Restrict exports to the mgmt network
+#
+# @example
+#   include xcat::master::nfs
+class xcat::master::nfs {
+
+    $mgmt_network = lookup( 'xcat::network_mgmt', String[11] )
+
+    $common_options = [ 'rw', 'no_root_squash', 'sync', 'no_subtree_check' ]
+
+    $mount_points = { '/tftpboot' => $common_options,
+                      '/install'  => $common_options,
+                    }
+
+    #
+    # Create a list of change strings for each mount point
+    $changes_map = $mount_points.reduce({}) |$memo, $tuple| {
+        $mount = $tuple[0]
+        $dir = "set dir[. = '${mount}'] ${mount}"
+        $from = "set dir[. = '${mount}']/client ${mgmt_network}"
+        $opts_list = $tuple[1]
+        # loop through options list, create a list of change strings for augeas
+        $opts_changes = $opts_list.reduce([]) |$ary, $opt| {
+            # Augeas /etc/exports options are 1-based
+            $i = length( $ary ) + 1
+            $new_change = "set dir[. = '${mount}']/client/option[${i}] ${opt}"
+            # return merge of ary and new change string
+            $ary + [ $new_change ]
+        }
+        # merge all change strings into a single array
+        $changes = [ $dir ] + [ $from ] + $opts_changes
+        # return merge of memo with new hash key and value
+        $memo + { $mount => $changes }
+    }
+
+    # Loop through mountpoints and apply changes (options) for each
+    $changes_map.each |$mount, $changes| {
+        augeas { "xcat master: limit nfs export of '${mount}' to mgmt network '${mgmt_network}'" :
+            context => '/files/etc/exports',
+            changes => $changes,
+        }
+    }
+
+#    # The above code will generate Puppet code like below,
+#    # for each mount_point
+#    augeas { 'limit /tftpboot nfs export to mgmt net':
+#        context => '/files/etc/exports',
+#        changes => [
+#            "set dir[. = '/tftpboot'] /tftpboot",
+#            "set dir[. = '/tftpboot']/client ${mgmt_network}",
+#            "set dir[. = '/tftpboot']/client/option[1] rw",
+#            "set dir[. = '/tftpboot']/client/option[2] no_root_squash",
+#            "set dir[. = '/tftpboot']/client/option[3] sync",
+#            "set dir[. = '/tftpboot']/client/option[4] no_subtree_check",
+#        ],
+#    }
+    # See also:
+    # https://puppet.com/docs/puppet/5.5/resources_augeas.html
+}

--- a/manifests/master/tcpwrappers.pp
+++ b/manifests/master/tcpwrappers.pp
@@ -1,0 +1,22 @@
+# @summary A short summary of the purpose of this class
+#
+# A description of what this class does
+#
+# @example
+#   include xcat::master::tcpwrappers
+class xcat::master::tcpwrappers {
+
+    $mgmt_network = lookup( 'xcat::network_mgmt', String[11] )
+    $ipmi_network = lookup( 'xcat::network_ipmi', String[11] )
+
+    tcpwrappers::allow { 'allow all from xcat mgmt network':
+        service => 'ALL',
+        address => $mgmt_network,
+    }
+
+    tcpwrappers::allow { 'allow all from xcat ipmi network':
+        service => 'ALL',
+        address => $ipmi_network,
+    }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -6,8 +6,14 @@
   "license": "NCSA",
   "source": "",
   "dependencies": [
-    { "name": "ncsa/ssh", "version_requirement": ">= 0.0.1" },
-    { "name": "inkblot-ipcalc", "version_requirement": ">= 2.2.0" }
+    {
+      "name": "ncsa/ssh",
+      "version_requirement": ">= 0.0.1"
+    },
+    {
+      "name": "inkblot-ipcalc",
+      "version_requirement": ">= 2.2.0"
+    }
   ],
   "operatingsystem_support": [
     {
@@ -41,7 +47,7 @@
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.10.0",
-  "template-url": "file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git#1.10.0",
-  "template-ref": "1.10.0-0-gbba9ac3"
+  "pdk-version": "1.13.0",
+  "template-url": "pdk-default#1.13.0",
+  "template-ref": "1.13.0-0-g66e1443"
 }

--- a/spec/classes/master/nfs_spec.rb
+++ b/spec/classes/master/nfs_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'xcat::master::nfs' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/master/tcpwrappers_spec.rb
+++ b/spec/classes/master/tcpwrappers_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'xcat::master::tcpwrappers' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,11 @@ default_fact_files.each do |f|
   end
 end
 
+# read default_facts and merge them over what is provided by facterdb
+default_facts.each do |fact, value|
+  add_custom_fact fact, value
+end
+
 RSpec.configure do |c|
   c.default_facts = default_facts
   c.before :each do
@@ -37,6 +42,8 @@ RSpec.configure do |c|
   end
 end
 
+# Ensures that a module is defined
+# @param module_name Name of the module
 def ensure_module_defined(module_name)
   module_name.split('::').reduce(Object) do |last_module, next_module|
     last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)


### PR DESCRIPTION
Restrict NFS access in tcpwrappers

pdk update from 1.10.0 to 1.13.0

Allow ALL services from xcat mgmt network

Manage tftpboot export with augeas

Dynamically generate changes to /etc/exports

Aesthetic fixes

Allow traffic from xCAT ipmi network